### PR TITLE
ChromeDriver のバージョンの採番ルール変更に追従

### DIFF
--- a/2.4/stretch/Dockerfile
+++ b/2.4/stretch/Dockerfile
@@ -24,8 +24,9 @@ ENV CHROMEDRIVER_PATH /usr/local/bin/chromedriver
 RUN sudo apt-get update && \
   sudo apt-get install -y chromium libgconf-2-4 unzip && \
   sudo rm -rf /var/lib/apt/lists/*
-RUN VERSION=$(curl -sL https://chromedriver.storage.googleapis.com/LATEST_RELEASE) && \
-  curl -L -o /tmp/chromedriver.zip https://chromedriver.storage.googleapis.com/${VERSION}/chromedriver_linux64.zip && \
+RUN CHROME_VERSION=$(dpkg -s chromium | perl -lne '/^Version: ([0-9]+\.[0-9]+\.[0-9]+)/ and print $1') && \
+  VERSION=$(curl -sL https://chromedriver.storage.googleapis.com/LATEST_RELEASE_${CHROME_VERSION}) && \
+    curl -L -o /tmp/chromedriver.zip https://chromedriver.storage.googleapis.com/${VERSION}/chromedriver_linux64.zip && \
   unzip -d /tmp /tmp/chromedriver.zip && \
   sudo cp /tmp/chromedriver /usr/local/bin/chromedriver && \
   rm -f /tmp/chromedriver*

--- a/2.5/stretch/Dockerfile
+++ b/2.5/stretch/Dockerfile
@@ -24,8 +24,9 @@ ENV CHROMEDRIVER_PATH /usr/local/bin/chromedriver
 RUN sudo apt-get update && \
   sudo apt-get install -y chromium libgconf-2-4 unzip && \
   sudo rm -rf /var/lib/apt/lists/*
-RUN VERSION=$(curl -sL https://chromedriver.storage.googleapis.com/LATEST_RELEASE) && \
-  curl -L -o /tmp/chromedriver.zip https://chromedriver.storage.googleapis.com/${VERSION}/chromedriver_linux64.zip && \
+RUN CHROME_VERSION=$(dpkg -s chromium | perl -lne '/^Version: ([0-9]+\.[0-9]+\.[0-9]+)/ and print $1') && \
+  VERSION=$(curl -sL https://chromedriver.storage.googleapis.com/LATEST_RELEASE_${CHROME_VERSION}) && \
+    curl -L -o /tmp/chromedriver.zip https://chromedriver.storage.googleapis.com/${VERSION}/chromedriver_linux64.zip && \
   unzip -d /tmp /tmp/chromedriver.zip && \
   sudo cp /tmp/chromedriver /usr/local/bin/chromedriver && \
   rm -f /tmp/chromedriver*


### PR DESCRIPTION
# 関連URL

* https://sites.google.com/a/chromium.org/chromedriver/downloads/version-selection

# 概要

* ChromeDriver のバージョンの採番ルールが変更された
* ChromeDriver 2.46 + GoogleChorome 72.0.36.26.96 の組み合わせだと以下のようなエラーが出る
  *  ChromeDriver との通信が失敗しているか Chrome が crash している可能性がある
```
     Selenium::WebDriver::Error::UnknownError:
       unknown error: Chrome failed to start: exited abnormally
         (unknown error: DevToolsActivePort file doesn't exist)
         (The process started from chrome location /usr/bin/chromium is no longer running, so ChromeDriver is assuming that Chrome has crashed.)
         (Driver info: chromedriver=2.43.600233 (523efee95e3d68b8719b3a1c83051aa63aa6b10d),platform=Linux 4.15.0-1027-aws x86_64)
```
  * この対応で改善しなければ動作が確認できている旧バージョンの組み合わせに戻す
    * 現在確認できているのは ChromeDriver 2.45 + GoogleChorome 70.0.3538.110
