### PR TITLE
一時的に Chrome と ChromeDriver が動作するバージョンに固定する

### DIFF
--- a/2.4/stretch/Dockerfile
+++ b/2.4/stretch/Dockerfile
@@ -22,11 +22,9 @@ RUN sudo pip3 install awscli && \
 # ChromeDriver
 ENV CHROMEDRIVER_PATH /usr/local/bin/chromedriver
 RUN sudo apt-get update && \
-  sudo apt-get install -y chromium libgconf-2-4 unzip && \
+  sudo apt-get install -y chromium=70.0.3538.110-1~deb9u1 libgconf-2-4 unzip && \
   sudo rm -rf /var/lib/apt/lists/*
-RUN CHROME_VERSION=$(dpkg -s chromium | perl -lne '/^Version: ([0-9]+\.[0-9]+\.[0-9]+)/ and print $1') && \
-  VERSION=$(curl -sL https://chromedriver.storage.googleapis.com/LATEST_RELEASE_${CHROME_VERSION}) && \
-    curl -L -o /tmp/chromedriver.zip https://chromedriver.storage.googleapis.com/${VERSION}/chromedriver_linux64.zip && \
+RUN curl -L -o /tmp/chromedriver.zip https://chromedriver.storage.googleapis.com/2.45/chromedriver_linux64.zip && \
   unzip -d /tmp /tmp/chromedriver.zip && \
   sudo cp /tmp/chromedriver /usr/local/bin/chromedriver && \
   rm -f /tmp/chromedriver*


### PR DESCRIPTION
#2 参照

2.4 環境のみ動作確認のため修正します