### PR TITLE
Ruby 2.4 の chrome, chromedriver のバージョンを最新のものを使用するように元に戻す

### DIFF
--- a/2.4/stretch/Dockerfile
+++ b/2.4/stretch/Dockerfile
@@ -22,9 +22,11 @@ RUN sudo pip3 install awscli && \
 # ChromeDriver
 ENV CHROMEDRIVER_PATH /usr/local/bin/chromedriver
 RUN sudo apt-get update && \
-  sudo apt-get install -y chromium=70.0.3538.110-1~deb9u1 libgconf-2-4 unzip && \
+  sudo apt-get install -y chromium libgconf-2-4 unzip && \
   sudo rm -rf /var/lib/apt/lists/*
-RUN curl -L -o /tmp/chromedriver.zip https://chromedriver.storage.googleapis.com/2.45/chromedriver_linux64.zip && \
+RUN CHROME_VERSION=$(dpkg -s chromium | perl -lne '/^Version: ([0-9]+\.[0-9]+\.[0-9]+)/ and print $1') && \
+  VERSION=$(curl -sL https://chromedriver.storage.googleapis.com/LATEST_RELEASE_${CHROME_VERSION}) && \
+    curl -L -o /tmp/chromedriver.zip https://chromedriver.storage.googleapis.com/${VERSION}/chromedriver_linux64.zip && \
   unzip -d /tmp /tmp/chromedriver.zip && \
   sudo chmod 755 /tmp/chromedriver && \
   sudo cp /tmp/chromedriver /usr/local/bin/chromedriver && \


### PR DESCRIPTION
## 概要

*  `Selenium::WebDriver::Error::UnknownError: unknown error: Chrome failed to start: exited abnormally` というエラーが出ていた問題について、#3 でchrome, chromedriver のバージョンを一時的に固定するように変更していた
* 直近のビルドではエラーが発生せず、再現が取れなくなったため、原因は不明だが問題は解消したものと判断
* Ruby2.5 のコンテナ側で異常が起きていない（chrome, chromedriver のバージョンは最新
* Ruby 2.4 のコンテナ側も chrome, chromedriver のバージョンを最新のものを使用するように元に戻します

## 変更内容

Revert "tmp: freeze chrome & chrome version"

This reverts commit 0bd2605aa332f688cfd3feda853e84ab5a137d8b.